### PR TITLE
Make `InvalidArg` error more verbose

### DIFF
--- a/src/gccrs/args.rs
+++ b/src/gccrs/args.rs
@@ -39,8 +39,12 @@ fn format_output_filename(
 ) -> Result<(PathBuf, CrateType)> {
     // Return an [`Error::InvalidArg`] error if `--crate-name` or `out-dir` weren't
     // given as arguments at this point of the translation
-    let crate_name = matches.opt_str("crate-name").ok_or(Error::InvalidArg)?;
-    let out_dir = matches.opt_str("out-dir").ok_or(Error::InvalidArg)?;
+    let crate_name = matches
+        .opt_str("crate-name")
+        .ok_or_else(|| Error::InvalidArg(String::from("no `--crate-name` provided")))?;
+    let out_dir = matches
+        .opt_str("out-dir")
+        .ok_or_else(|| Error::InvalidArg(String::from("no `--out-dir` provided")))?;
     let c_options = matches.opt_strs("C");
 
     let mut output_file = PathBuf::from(&out_dir);

--- a/src/gccrs/error.rs
+++ b/src/gccrs/error.rs
@@ -8,7 +8,7 @@ use getopts::Fail;
 #[derive(Debug)]
 pub enum Error {
     /// Invalid argument given to `gccrs`
-    InvalidArg,
+    InvalidArg(String),
     /// Invalid config line dumped when executing `gccrs -frust-dump-*`
     InvalidCfgDump,
     /// Error when compiling a program using `gccrs`
@@ -27,7 +27,7 @@ impl From<IoError> for Error {
 // If parsing the options using `getopts` fail, then it was because an unhandled argument
 // was given to the translation unit
 impl From<Fail> for Error {
-    fn from(_: Fail) -> Self {
-        Error::InvalidArg
+    fn from(arg_fail: Fail) -> Self {
+        Error::InvalidArg(arg_fail.to_string())
     }
 }


### PR DESCRIPTION
Closes #14 

This PR makes `InvalidArg` errors clearer, which in turn will help development:

```sh
> cargo gccrs build
thread 'main' panicked at 'cannot translate rustc arguments into gccrs ones: InvalidArg("Unrecognized option: \'cfg\'")', src/main.rs:29:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'cannot translate rustc arguments into gccrs ones: InvalidArg("Unrecognized option: \'cap-lints\'")', src/main.rs:29:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```