### PR TITLE
Check correct filename between rustc and gccrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ repository = "https://github.com/Rust-GCC/cargo-gccrs"
 
 [dependencies]
 getopts = "0.2"
+
+[dev-dependencies]
+tempdir = "0.3"

--- a/src/gccrs/args.rs
+++ b/src/gccrs/args.rs
@@ -62,7 +62,9 @@ fn format_output_filename(
                 None
             }
         })
-        .collect::<Vec<&str>>()[0];
+        .collect::<Vec<&str>>()
+        .pop()
+        .unwrap_or("");
 
     match crate_type {
         CrateType::Bin => output_file.push(&format!("{}{}", crate_name, extra_filename)),

--- a/tests/functional_tests.rs
+++ b/tests/functional_tests.rs
@@ -10,9 +10,7 @@ mod tests {
 
     #[test]
     fn check_project_compilation() {
-        TEST_FOLDERS
-            .iter()
-            .for_each(|f| Harness::check_folder(*f).unwrap());
+        TEST_FOLDERS.iter().for_each(|f| Harness::check_folder(*f).unwrap());
 
         assert!(Harness::check_folder("invalid_code").is_err())
     }

--- a/tests/functional_tests.rs
+++ b/tests/functional_tests.rs
@@ -12,6 +12,8 @@ mod tests {
         Harness::check_folder("static_lib", FileType::Static).unwrap();
         Harness::check_folder("shared_library", FileType::Dyn).unwrap();
 
+        // FIXME: As of right now, this just fails on rustc compilation which is not what
+        // we want to check
         assert!(Harness::check_folder("invalid_code", FileType::Bin).is_err())
     }
 }

--- a/tests/functional_tests.rs
+++ b/tests/functional_tests.rs
@@ -1,17 +1,17 @@
 mod test_harness;
 
-use test_harness::Harness;
+use test_harness::{FileType, Harness};
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const TEST_FOLDERS: &[&str] = &["binary_project", "static_lib", "shared_library"];
-
     #[test]
     fn check_project_compilation() {
-        TEST_FOLDERS.iter().for_each(|f| Harness::check_folder(*f).unwrap());
+        Harness::check_folder("binary_project", FileType::Bin).unwrap();
+        Harness::check_folder("static_lib", FileType::Static).unwrap();
+        Harness::check_folder("shared_library", FileType::Dyn).unwrap();
 
-        assert!(Harness::check_folder("invalid_code").is_err())
+        assert!(Harness::check_folder("invalid_code", FileType::Bin).is_err())
     }
 }

--- a/tests/test_harness.rs
+++ b/tests/test_harness.rs
@@ -1,3 +1,5 @@
+use tempdir::TempDir;
+
 use std::{
     env::{self, join_paths},
     io::{Error, ErrorKind, Result},
@@ -41,6 +43,16 @@ impl Harness {
         })
     }
 
+    /// Copy a folder to a set destination
+    fn copy_folder(src: &str, dest: &str) -> Result {
+        Command::new("cp")
+            .arg("-r")
+            .arg(src)
+            .arg(dest)
+            .status()
+            .into_result()
+    }
+
     /// Runs the folder generic test suite on a give folder. This test suite
     /// makes sure that the project compiles using `rustc` as well as `gccrs`,
     /// before verifying that both compilers output create binaires with the
@@ -54,6 +66,10 @@ impl Harness {
 
         // Build the project using rustc
         Harness::cargo_build(false)?;
+
+        // Copy the rustc target folder to a temporary directory
+        let rustc_target_tmpdir = TempDir::new("target-rustc")?;
+        Harness::copy_folder("target", rustc_target_tmpdir.path().to_str().unwrap())?;
 
         // Build the project using gccrs
         Harness::cargo_build(true)?;


### PR DESCRIPTION
This PR adds functional testing for checking that the binaries produced by `rustc` and `gccrs` both have the same filename.

One thing that I'm not too happy with is that we cannot benefit from having multiple tests. Since tests run in parallel, and that AFAIK there is no way to specify `--test-threads=1` in a configuration file, we are stuck with having to check a lot of conditions for each test folder, all at once, or else we'd run in parallelism issues. 

I guess we could at least split the main functional test function (`check_compilation`) but it would mean changing the way we compile projects, as this implementation currently `cd`s into the project directory before building it.