### PR TITLE
Remove misuse of !cfg(release)

### DIFF
--- a/src/gccrs/mod.rs
+++ b/src/gccrs/mod.rs
@@ -29,14 +29,7 @@ impl Gccrs {
     /// yet. This function is only available in debug mode, not release, in order for
     /// users to be aware of the limitations.
     fn fake_output(s: &str) {
-        if cfg!(release) {
-            unreachable!(
-                "gccrs cannot yet produce the following, expected output: {}",
-                s
-            );
-        } else {
-            println!("{}", s);
-        }
+        println!("{}", s);
     }
 
     fn dump_config() -> CmdResult<ExitStatus> {


### PR DESCRIPTION
Thanks to @bjorn3 for explaining how the check was useless.

I guess we could keep the fake output until `gccrs` can output the correct expected file names