### PR TITLE
Refactor `GccrsArgs` structure

### DIFF
--- a/src/gccrs/args.rs
+++ b/src/gccrs/args.rs
@@ -92,7 +92,6 @@ pub struct GccrsArgs {
     source_files: Vec<String>,
     crate_type: CrateType,
     output_file: PathBuf,
-    callback: Option<&'static dyn Fn(&GccrsArgs) -> Result>,
 }
 
 impl GccrsArgs {
@@ -101,7 +100,6 @@ impl GccrsArgs {
             source_files: Vec::from(source_files),
             crate_type,
             output_file,
-            callback: None,
         }
     }
 
@@ -115,20 +113,9 @@ impl GccrsArgs {
         &self.output_file
     }
 
-    /// Set the callback of an argument set
-    pub fn set_callback(&mut self, function: &'static dyn Fn(&GccrsArgs) -> Result) {
-        self.callback = Some(function);
-    }
-
     /// Get a reference to the set of arguments' type of binary produced
     pub fn crate_type(&self) -> CrateType {
         self.crate_type
-    }
-
-    // Execute an argument set's callback if present. Returns Ok if no callback was
-    // present
-    pub fn callback(&self) -> Option<&'static dyn Fn(&GccrsArgs) -> Result> {
-        self.callback
     }
 
     /// Get the corresponding `gccrs` argument from a given `rustc` argument

--- a/src/gccrs/args.rs
+++ b/src/gccrs/args.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use getopts::Matches;
 
-use super::{Error, Result, RustcOptions, EnvArgs};
+use super::{EnvArgs, Error, Result, RustcOptions};
 
 /// Crate types supported by `gccrs`
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -172,7 +172,7 @@ impl GccrsArgs {
                 String::from("-o"),
                 self.object_file_name().into_os_string().into_string()?,
             ]),
-            CrateType::Unknown => {},
+            CrateType::Unknown => {}
         }
 
         Ok(args)

--- a/src/gccrs/args.rs
+++ b/src/gccrs/args.rs
@@ -171,7 +171,10 @@ impl Args {
 
     /// Add `.tmp.o` to the expected output filename.
     pub fn object_file_name(&self) -> PathBuf {
-        self.output_file.clone().join(".tmp.o")
+        let mut tmp_object_path = self.output_file.clone();
+        tmp_object_path.set_extension("tmp_object.o");
+
+        tmp_object_path
     }
 
     /// Get a reference to the set of arguments' output file path

--- a/src/gccrs/args.rs
+++ b/src/gccrs/args.rs
@@ -48,11 +48,11 @@ pub struct ArgsCollection {
 }
 
 /// Get the corresponding set of `gccrs` arguments from a single set of `rustc` arguments
-impl TryFrom<&[String]> for ArgsCollection {
+impl TryFrom<&RustcArgs> for ArgsCollection {
     type Error = Error;
 
-    fn try_from(rustc_args: &[String]) -> Result<ArgsCollection> {
-        let matches = RustcArgs::new().parse(rustc_args)?;
+    fn try_from(rustc_args: &RustcArgs) -> Result<ArgsCollection> {
+        let matches = rustc_args.matches();
 
         let args_set: Result<Vec<Args>> = matches
             .opt_strs("crate-type")
@@ -105,14 +105,6 @@ impl<'a> From<&'a str> for CrateType {
             _ => CrateType::Unknown,
         }
     }
-}
-
-/// Add `.tmp.o` to the expected output filename. Since we will already have produced the
-/// expected filename at this point, and we are likely currently converting it to a String
-/// to spawn as an argument, this function can avoid taking a Path as parameter and returning
-/// a PathBuf.
-fn object_file_name(output_file: &str) -> String {
-    format!("{}.tmp.o", output_file)
 }
 
 fn format_output_filename(

--- a/src/gccrs/args.rs
+++ b/src/gccrs/args.rs
@@ -3,9 +3,9 @@
 
 use std::{env, path::PathBuf, process::Command};
 
-use getopts::{Matches, Options};
+use getopts::Matches;
 
-use super::{Error, Result};
+use super::{Error, Result, RustcOptions};
 
 /// Crate types supported by `gccrs`
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -96,31 +96,6 @@ pub struct GccrsArgs {
 }
 
 impl GccrsArgs {
-    fn generate_parser() -> Options {
-        let mut options = Options::new();
-        options.optopt("", "crate-name", "Name of the crate to compile", "NAME");
-        options.optopt("", "edition", "Rust edition to use", "YEAR");
-        options.optopt("", "error-format", "Requested error format", "EXTENSION");
-        options.optopt(
-            "",
-            "out-dir",
-            "Directory in which to output generated files",
-            "DIR",
-        );
-        options.optopt("", "emit", "Requested output to emit", "KIND");
-        options.optopt("", "json", "JSON Rendering type", "RENDER");
-        options.optmulti("C", "", "Extra compiler options", "OPTION[=VALUE]");
-        options.optmulti(
-            "L",
-            "",
-            "Add a directory to the library's search path",
-            "KIND[=PATH]",
-        );
-        options.optmulti("", "crate-type", "Type of binary to output", "TYPE");
-
-        options
-    }
-
     fn generate_static_lib(args: &GccrsArgs) -> Result {
         let output_file = args
             .output_file
@@ -175,10 +150,7 @@ impl GccrsArgs {
 
     /// Get the corresponding `gccrs` argument from a given `rustc` argument
     pub fn from_rustc_args(rustc_args: &[String]) -> Result<Vec<GccrsArgs>> {
-        let options = GccrsArgs::generate_parser();
-
-        // Parse arguments, skipping `cargo-gccrs` and `rustc` in the invocation
-        let matches = options.parse(&rustc_args[2..])?;
+        let matches = RustcOptions::new().parse(rustc_args)?;
 
         matches
             .opt_strs("crate-type")

--- a/src/gccrs/config.rs
+++ b/src/gccrs/config.rs
@@ -69,7 +69,7 @@ impl PartialOrd for DumpedOption {
     }
 }
 
-/// Sort DumpedOptions based on syntax printing rules. `rustc` prints target options in
+/// Sort DumpedArgs based on syntax printing rules. `rustc` prints target options in
 /// alphabetical order, before printing OS information
 impl Ord for DumpedOption {
     fn cmp(&self, other: &Self) -> Ordering {

--- a/src/gccrs/env_args.rs
+++ b/src/gccrs/env_args.rs
@@ -1,0 +1,26 @@
+//! Fetch extra arguments from the environment
+
+/// All kinds of availabe environment arguments
+pub enum EnvArgs {
+    /// Arguments used when creating a static library
+    Ar,
+    /// Arguments given to the compiler during compilation
+    Gcc,
+}
+
+impl EnvArgs {
+    /// Get the environment variable key associated with an instance of EnvArgs
+    fn as_key(&self) -> &'static str {
+        match self {
+            EnvArgs::Ar => "AR_EXTRA_ARGS",
+            EnvArgs::Gcc => "GCCRS_EXTRA_ARGS",
+        }
+    }
+
+    /// Fetch the extra arguments given by the user for a specific environment string
+    pub fn as_args(&self) -> Option<Vec<String>> {
+        std::env::var(self.as_key())
+            .map(|s| s.split(' ').map(|arg| arg.to_owned()).collect())
+            .ok()
+    }
+}

--- a/src/gccrs/error.rs
+++ b/src/gccrs/error.rs
@@ -1,5 +1,6 @@
 //! Error type of the `gccrs` abstraction
 
+use std::ffi::OsString;
 use std::io::Error as IoError;
 
 use getopts::Fail;
@@ -15,19 +16,29 @@ pub enum Error {
     CompileError,
     /// IO Error when executing a `gccrs` command
     CommandError(IoError),
+    /// Error when dealing with UTF-8 strings
+    Utf8Error(Option<OsString>),
 }
 
-// IO Error should be kept for better debugging
+/// IO Error should be kept for better debugging
 impl From<IoError> for Error {
     fn from(e: IoError) -> Self {
         Error::CommandError(e)
     }
 }
 
-// If parsing the options using `getopts` fail, then it was because an unhandled argument
-// was given to the translation unit
+/// If parsing the options using `getopts` fail, then it was because an unhandled argument
+/// was given to the translation unit
 impl From<Fail> for Error {
     fn from(arg_fail: Fail) -> Self {
         Error::InvalidArg(arg_fail.to_string())
+    }
+}
+
+/// UTF-8 errors happen when dealing with paths that are not UTF-8 encoded. For now,
+/// `cargo-gccrs` cannot handle them
+impl From<OsString> for Error {
+    fn from(s: OsString) -> Self {
+        Error::Utf8Error(Some(s))
     }
 }

--- a/src/gccrs/mod.rs
+++ b/src/gccrs/mod.rs
@@ -4,10 +4,12 @@
 mod args;
 mod config;
 mod error;
+mod rustc_options;
 
 use args::GccrsArgs;
 use config::GccrsConfig;
 use error::Error;
+use rustc_options::RustcOptions;
 
 use std::process::{Command, ExitStatus, Stdio};
 

--- a/src/gccrs/mod.rs
+++ b/src/gccrs/mod.rs
@@ -7,12 +7,13 @@ mod env_args;
 mod error;
 mod rustc_options;
 
-use args::{CrateType, GccrsArgs};
+use args::{CrateType, GccrsArgs, GccrsArgsCollection};
 use config::GccrsConfig;
 use env_args::EnvArgs;
 use error::Error;
 use rustc_options::RustcOptions;
 
+use std::convert::TryFrom;
 use std::process::{Command, ExitStatus, Stdio};
 
 pub struct Gccrs;
@@ -113,7 +114,7 @@ impl Gccrs {
     }
 
     fn translate_and_compile(args: &[String]) -> Result {
-        let gccrs_args = GccrsArgs::from_rustc_args(args)?;
+        let gccrs_args = GccrsArgsCollection::try_from(args)?;
 
         for arg_set in gccrs_args.iter() {
             Gccrs::compile(arg_set)?;

--- a/src/gccrs/mod.rs
+++ b/src/gccrs/mod.rs
@@ -114,7 +114,8 @@ impl Gccrs {
     }
 
     fn translate_and_compile(args: &[String]) -> Result {
-        let gccrs_args = ArgsCollection::try_from(args)?;
+        let rustc_args = RustcArgs::try_from(args)?;
+        let gccrs_args = ArgsCollection::try_from(&rustc_args)?;
 
         for arg_set in gccrs_args.iter() {
             Gccrs::compile(arg_set)?;

--- a/src/gccrs/mod.rs
+++ b/src/gccrs/mod.rs
@@ -5,13 +5,13 @@ mod args;
 mod config;
 mod env_args;
 mod error;
-mod rustc_options;
+mod rustc_args;
 
-use args::{CrateType, GccrsArgs, GccrsArgsCollection};
+use args::{Args, ArgsCollection, CrateType};
 use config::GccrsConfig;
 use env_args::EnvArgs;
 use error::Error;
-use rustc_options::RustcOptions;
+use rustc_args::RustcArgs;
 
 use std::convert::TryFrom;
 use std::process::{Command, ExitStatus, Stdio};
@@ -92,7 +92,7 @@ impl Gccrs {
     }
 
     /// Spawn a `gccrs` command with arguments extracted from a `rustc` invokation
-    fn compile(gccrs_args: &GccrsArgs) -> Result {
+    fn compile(gccrs_args: &Args) -> Result {
         let exit_status = Gccrs::spawn_with_args(&gccrs_args.as_args()?)?;
 
         match exit_status.success() {
@@ -103,7 +103,7 @@ impl Gccrs {
 
     /// Execute a callback if necessary, based on the different options used to build
     /// the `gccrs` arguments
-    fn maybe_callback(gccrs_args: &GccrsArgs) -> Result {
+    fn maybe_callback(gccrs_args: &Args) -> Result {
         // If we are ordered to generate a static library, call `ar` after compiling
         // the object files
         if gccrs_args.crate_type() == CrateType::StaticLib {
@@ -114,7 +114,7 @@ impl Gccrs {
     }
 
     fn translate_and_compile(args: &[String]) -> Result {
-        let gccrs_args = GccrsArgsCollection::try_from(args)?;
+        let gccrs_args = ArgsCollection::try_from(args)?;
 
         for arg_set in gccrs_args.iter() {
             Gccrs::compile(arg_set)?;
@@ -124,7 +124,7 @@ impl Gccrs {
         Ok(())
     }
 
-    fn generate_static_lib(args: &GccrsArgs) -> Result {
+    fn generate_static_lib(args: &Args) -> Result {
         let output_file = args
             .output_file()
             .to_str()

--- a/src/gccrs/mod.rs
+++ b/src/gccrs/mod.rs
@@ -3,11 +3,13 @@
 
 mod args;
 mod config;
+mod env_args;
 mod error;
 mod rustc_options;
 
-use args::GccrsArgs;
+use args::{CrateType, GccrsArgs};
 use config::GccrsConfig;
+use env_args::EnvArgs;
 use error::Error;
 use rustc_options::RustcOptions;
 
@@ -91,8 +93,12 @@ impl Gccrs {
     fn compile(args: &[String]) -> Result {
         let gccrs_args = GccrsArgs::from_rustc_args(args)?;
 
-        for arg_set in gccrs_args.into_iter() {
-            let exit_status = Gccrs::spawn_with_args(&arg_set.as_args())?;
+        for mut arg_set in gccrs_args.into_iter() {
+            if arg_set.crate_type() == CrateType::StaticLib {
+                arg_set.set_callback(&Gccrs::generate_static_lib);
+            }
+
+            let exit_status = Gccrs::spawn_with_args(&arg_set.as_args()?)?;
             if !exit_status.success() {
                 return Err(Error::CompileError);
             }
@@ -101,6 +107,27 @@ impl Gccrs {
                 callback(&arg_set)?
             }
         }
+
+        Ok(())
+    }
+
+    fn generate_static_lib(args: &GccrsArgs) -> Result {
+        let output_file = args
+            .output_file()
+            .to_str()
+            .expect("Cannot handle non-unicode filenames yet");
+
+        let mut ar_args = vec![
+            String::from("rcs"), // Create the archive and add the files to it
+            output_file.to_owned(),
+            args.object_file_name().into_os_string().into_string()?,
+        ];
+
+        if let Some(mut extra_ar_args) = EnvArgs::Ar.as_args() {
+            ar_args.append(&mut extra_ar_args);
+        }
+
+        Command::new("ar").args(ar_args).status()?;
 
         Ok(())
     }

--- a/src/gccrs/rustc_args.rs
+++ b/src/gccrs/rustc_args.rs
@@ -30,6 +30,13 @@ impl RustcArgs {
             "KIND[=PATH]",
         );
         options.optmulti("", "crate-type", "Type of binary to output", "TYPE");
+        options.optmulti(
+            "",
+            "cap-lints",
+            "Set the most restrictive lint level",
+            "LEVEL",
+        );
+        options.optmulti("", "cfg", "Configure the compilation environment", "SPEC");
 
         RustcArgs { options }
     }

--- a/src/gccrs/rustc_args.rs
+++ b/src/gccrs/rustc_args.rs
@@ -1,15 +1,18 @@
-use super::Result;
-/// This module implements `rustc`'s options parser. Ultimately, this should be directly
-/// taken from `rustc`'s implementation
+//! This module implements `rustc`'s options parser. Ultimately, this should be directly
+//! taken from `rustc`'s implementation
+
+use super::{Error, Result};
 use getopts::{Matches, Options};
+use std::convert::TryFrom;
 
 pub struct RustcArgs {
-    options: Options,
+    matches: Matches,
 }
 
-impl RustcArgs {
-    /// Generate a new options parser according to `rustc`'s command line options
-    pub fn new() -> RustcArgs {
+impl TryFrom<&[String]> for RustcArgs {
+    type Error = Error;
+
+    fn try_from(args: &[String]) -> Result<Self> {
         let mut options = Options::new();
         options.optopt("", "crate-name", "Name of the crate to compile", "NAME");
         options.optopt("", "edition", "Rust edition to use", "YEAR");
@@ -38,11 +41,15 @@ impl RustcArgs {
         );
         options.optmulti("", "cfg", "Configure the compilation environment", "SPEC");
 
-        RustcArgs { options }
-    }
-
-    pub fn parse(&self, args: &[String]) -> Result<Matches> {
         // Parse arguments, skipping `cargo-gccrs` and `rustc` in the invocation
-        Ok(self.options.parse(&args[2..])?)
+        Ok(RustcArgs {
+            matches: options.parse(&args[2..])?,
+        })
+    }
+}
+
+impl RustcArgs {
+    pub fn matches(&self) -> &Matches {
+        &self.matches
     }
 }

--- a/src/gccrs/rustc_args.rs
+++ b/src/gccrs/rustc_args.rs
@@ -3,13 +3,13 @@ use super::Result;
 /// taken from `rustc`'s implementation
 use getopts::{Matches, Options};
 
-pub struct RustcOptions {
+pub struct RustcArgs {
     options: Options,
 }
 
-impl RustcOptions {
+impl RustcArgs {
     /// Generate a new options parser according to `rustc`'s command line options
-    pub fn new() -> RustcOptions {
+    pub fn new() -> RustcArgs {
         let mut options = Options::new();
         options.optopt("", "crate-name", "Name of the crate to compile", "NAME");
         options.optopt("", "edition", "Rust edition to use", "YEAR");
@@ -31,7 +31,7 @@ impl RustcOptions {
         );
         options.optmulti("", "crate-type", "Type of binary to output", "TYPE");
 
-        RustcOptions { options }
+        RustcArgs { options }
     }
 
     pub fn parse(&self, args: &[String]) -> Result<Matches> {

--- a/src/gccrs/rustc_options.rs
+++ b/src/gccrs/rustc_options.rs
@@ -1,0 +1,43 @@
+use super::Result;
+/// This module implements `rustc`'s options parser. Ultimately, this should be directly
+/// taken from `rustc`'s implementation
+use getopts::{Matches, Options};
+
+pub struct RustcOptions {
+    options: Options,
+}
+
+impl RustcOptions {
+    /// Generate a new options parser according to `rustc`'s command line options
+    pub fn new() -> RustcOptions {
+        let mut options = Options::new();
+        options.optopt("", "crate-name", "Name of the crate to compile", "NAME");
+        options.optopt("", "edition", "Rust edition to use", "YEAR");
+        options.optopt("", "error-format", "Requested error format", "EXTENSION");
+        options.optopt(
+            "",
+            "out-dir",
+            "Directory in which to output generated files",
+            "DIR",
+        );
+        options.optopt("", "emit", "Requested output to emit", "KIND");
+        options.optopt("", "json", "JSON Rendering type", "RENDER");
+        options.optmulti("C", "", "Extra compiler options", "OPTION[=VALUE]");
+        options.optmulti(
+            "L",
+            "",
+            "Add a directory to the library's search path",
+            "KIND[=PATH]",
+        );
+        options.optmulti("", "crate-type", "Type of binary to output", "TYPE");
+
+        RustcOptions { options }
+    }
+
+    pub fn parse(&self, args: &[String]) -> Result<Matches> {
+        // Parse arguments, skipping `cargo-gccrs` and `rustc` in the invocation
+        let matches = self.options.parse(&args[2..])?;
+
+        Ok(matches)
+    }
+}

--- a/src/gccrs/rustc_options.rs
+++ b/src/gccrs/rustc_options.rs
@@ -36,8 +36,6 @@ impl RustcOptions {
 
     pub fn parse(&self, args: &[String]) -> Result<Matches> {
         // Parse arguments, skipping `cargo-gccrs` and `rustc` in the invocation
-        let matches = self.options.parse(&args[2..])?;
-
-        Ok(matches)
+        Ok(self.options.parse(&args[2..])?)
     }
 }


### PR DESCRIPTION
This PR cleans up the `GccrsArgs` type by splitting it in multiple modules. As pointed out by @philberty and @flip1995, the type should be doing much less than what is currently implemented.

Closes #23 