### PR TITLE
Handle `--cfg` and `--cap-lints` options

### DIFF
--- a/src/gccrs/rustc_options.rs
+++ b/src/gccrs/rustc_options.rs
@@ -30,6 +30,13 @@ impl RustcOptions {
             "KIND[=PATH]",
         );
         options.optmulti("", "crate-type", "Type of binary to output", "TYPE");
+        options.optmulti(
+            "",
+            "cap-lints",
+            "Set the most restrictive lint level",
+            "LEVEL",
+        );
+        options.optmulti("", "cfg", "Configure the compilation environment", "SPEC");
 
         RustcOptions { options }
     }


### PR DESCRIPTION
Needs #47 to be merged

Closes #16
Closes #17 

This PR adds the handling of those options to the rustc option parser generator. This will no longer be an issue once #46 is done, but is necessary for now in order to compile certain crates.

I added the corresponding compiler issues links (Rust-GCC/gccrs#575 and Rust-GCC/gccrs#574) in the commit's message for future reference

