### PR TITLE
args: Remove impl Deref for ArgsCollection

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -2,7 +2,6 @@
 //! arguments for `gccrs`.
 
 use std::convert::TryFrom;
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 use getopts::Matches;
@@ -72,11 +71,9 @@ impl TryFrom<&RustcArgs> for ArgsCollection {
     }
 }
 
-/// Implement deref on the collection so we can easily iterate on it
-impl Deref for ArgsCollection {
-    type Target = Vec<Args>;
-
-    fn deref(&self) -> &Self::Target {
+impl ArgsCollection {
+    /// Access the collection's inner data
+    pub fn data(&self) -> &Vec<Args> {
         &self.args_set
     }
 }

--- a/src/gccrs.rs
+++ b/src/gccrs.rs
@@ -95,7 +95,7 @@ impl Gccrs {
         let rustc_args = RustcArgs::try_from(args)?;
         let gccrs_args = ArgsCollection::try_from(&rustc_args)?;
 
-        for arg_set in gccrs_args.iter() {
+        for arg_set in gccrs_args.data().iter() {
             Gccrs::compile(arg_set)?;
             Gccrs::maybe_callback(arg_set)?;
         }


### PR DESCRIPTION
The Deref trait should only be used for smart pointers to avoid any
confusion
