### PR TITLE
ci: Remove Rust installation in CI

### DIFF
--- a/.github/workflows/fmt_build_tests.yml
+++ b/.github/workflows/fmt_build_tests.yml
@@ -33,11 +33,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
       - name: Run unit and functional tests
         run: |
-          apt update
-          apt install ca-certificates -y
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          . $HOME/.cargo/env
           cargo test

--- a/src/args.rs
+++ b/src/args.rs
@@ -130,7 +130,7 @@ fn format_output_filename(
         .filter_map(|c_opt| {
             let mut split = c_opt.split('=');
 
-            if let Some("extra-filename") = split.next().as_deref() {
+            if let Some("extra-filename") = split.next() {
                 split.next()
             } else {
                 None

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,10 +95,7 @@ impl GccrsConfig {
     }
 
     fn parse(input: String) -> Result<Vec<DumpedOption>> {
-        input
-            .lines()
-            .map(|line| DumpedOption::from_str(line))
-            .collect()
+        input.lines().map(DumpedOption::from_str).collect()
     }
 
     /// Create a new instance `GccrsConfig` with a call to the `gccrs` compiler


### PR DESCRIPTION
Since we have access to rust directly from the base image, this hack is not needed anymore