### PR TITLE
gccrs: Fix language option in dump_config()

### DIFF
--- a/src/gccrs.rs
+++ b/src/gccrs.rs
@@ -29,7 +29,7 @@ impl Gccrs {
     fn dump_config() -> CmdResult<ExitStatus> {
         Command::new("gccrs")
             .arg("-x")
-            .arg("rs")
+            .arg("rust")
             .arg("-frust-dump-target_options")
             .arg("-")
             .status()


### PR DESCRIPTION
Follow the change that the language spec rs was renamed to rust.
[3f3b4a45eb90b5afdfd9d067fd9ea7969b5a69d6](https://github.com/Rust-GCC/gccrs/commit/3f3b4a45eb90b5afdfd9d067fd9ea7969b5a69d6)