### PR TITLE
clippy: Fix a recent warning

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ enum DumpedOption {
 
 impl DumpedOption {
     fn parse_multi_value(input: Vec<&str>) -> Option<DumpedOption> {
-        let key = input.get(0)?.to_string();
+        let key = input.first()?.to_string();
         let value = input.get(1)?.trim_start().to_string();
 
         Some(DumpedOption::TargetSpecific(key, value))


### PR DESCRIPTION
```
$ cargo clippy -V
clippy 0.1.66 (69f9c33 2022-12-12)
```