### PR TITLE
readme: Fix `cargo install` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Since the project does not contain any releases yet, you can install it from git
 the following command:
 
 ```sh
-> cargo install --git https://github.com/Rust-GCC/cargo-gccrs
+> cargo install --git https://github.com/Rust-GCC/cargo-gccrs cargo-gccrs
 ```
 
 ## Usage


### PR DESCRIPTION
Current install command does not work:
```console
❯ cargo install --git https://github.com/Rust-GCC/cargo-gccrs
    Updating git repository `https://github.com/Rust-GCC/cargo-gccrs`
error: multiple packages with binaries found: binary_project, cargo-gccrs, invalid_code, rustflags_project, warning_project. When installing a git repository, cargo will always search the entire repo for any Cargo.toml. Please specify which to install.
```